### PR TITLE
chore: i18next を v26 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "i18next": "^25.9.0",
+        "i18next": "^26.0.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-i18next": "^15.7.4",
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3565,29 +3565,29 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.9.0.tgz",
-      "integrity": "sha512-mJ4rVRNWOTkqh5xnaGR6iMFT5vEw3Y2MTJhcjinR/7u8cRv6dAfC0ofuePh5fVPxoh395p6JdrJTStCcNW66gg==",
+      "version": "26.0.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.3.tgz",
+      "integrity": "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
-        "typescript": "^5"
+        "typescript": "^5 || ^6"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "i18next": "^25.9.0",
+    "i18next": "^26.0.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-i18next": "^15.7.4",


### PR DESCRIPTION
## 概要
- `i18next` を `^25.9.0` から `^26.0.3` へメジャー更新しました。
- メジャー更新のため、1依存関係のみをこのPRで更新しています。

## 変更内容
- `package.json` の `i18next` バージョンを更新
- `package-lock.json` を更新

## 事前確認（Breaking Changes / Changelog）
`i18next` CHANGELOG の `26.0.0` を確認し、以下の破壊的変更を確認しました。
- `initImmediate` オプションの削除（`initAsync` を使用）
- 旧 `interpolation.format` 関数の削除（Formatter API へ移行）
- `showSupportNotice` / `simplifyPluralSuffix` などの削除

本リポジトリ内では上記オプション・APIの利用がないことを確認済みです。

## 検証
- `npm test` ✅
- `npm run build` ✅

CI（PRチェック）成功後にマージ予定です。