### PR TITLE
chore: @types/node を v25 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "colamone",
       "version": "1.0.0",
       "dependencies": {
-        "@types/node": "^24.12.0",
+        "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "i18next": "^25.9.0",
@@ -1524,12 +1524,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
@@ -5672,9 +5672,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "homepage": "./",
   "dependencies": {
-    "@types/node": "^24.12.0",
+    "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "i18next": "^25.9.0",


### PR DESCRIPTION
## 概要
- `@types/node` を `^24.12.0` から `^25.5.0` へメジャー更新しました。
- メジャー更新のため、1依存関係のみをこのPRで更新しています。

## 変更内容
- `package.json` の `@types/node` バージョンを更新
- `package-lock.json` を更新

## 事前確認（Breaking Changes / Changelog）
- Node.js v25.0.0 のリリースノート（Semver-Major / Deprecations and Removals）を確認
- `@types/node` は Node.js API 型定義のメジャー追従であり、型の厳格化・非推奨APIの型変更が主な影響
- 本リポジトリでは `npm test` / `npm run build` が通過し、既存コードで型破壊は発生していないことを確認

## 検証
- `npm test` ✅
- `npm run build` ✅

CI（PRチェック）成功後にマージ予定です。