### PR TITLE
chore: .npmrc に min-release-age=2880（2日）を設定

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2880


### PR DESCRIPTION
## 概要
`.npmrc` に `min-release-age=2880`（2日）を追加し、公開直後のパッケージ取り込みリスクを下げます。

## 変更内容
- `.npmrc` を追加（または追記）
- `min-release-age=2880` を設定

## 補足
- 設定追加のみのため、テストは実施していません。
