### PR TITLE
ci: safe-chainログをsilent化してFirebase deployのJSONパース失敗を回避

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Build
         run: npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        env:
+          SAFE_CHAIN_LOGGING: silent
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_COLAMONE_26F99 }}'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Build
         run: npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        env:
+          SAFE_CHAIN_LOGGING: silent
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_COLAMONE_26F99 }}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "i18next": "^25.9.0",
+        "i18next": "^26.0.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-i18next": "^15.7.4",
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3565,29 +3565,29 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.9.0.tgz",
-      "integrity": "sha512-mJ4rVRNWOTkqh5xnaGR6iMFT5vEw3Y2MTJhcjinR/7u8cRv6dAfC0ofuePh5fVPxoh395p6JdrJTStCcNW66gg==",
+      "version": "26.0.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.3.tgz",
+      "integrity": "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
-        "typescript": "^5"
+        "typescript": "^5 || ^6"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "i18next": "^25.9.0",
+    "i18next": "^26.0.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-i18next": "^15.7.4",


### PR DESCRIPTION
## 概要
Firebase Hosting デプロイ時に `firebase-tools --json` 出力へ safe-chain のログが混入し、`action-hosting-deploy` が JSON パースで失敗する問題を修正します。

## 変更内容
- `firebase-hosting-merge.yml` の `FirebaseExtended/action-hosting-deploy@v0` step に `SAFE_CHAIN_LOGGING: silent` を追加
- `firebase-hosting-pull-request.yml` の `FirebaseExtended/action-hosting-deploy@v0` step に `SAFE_CHAIN_LOGGING: silent` を追加

## 期待される効果
- safe-chain の情報ログ（`ℹ ...`）が `--json` 出力に混ざらなくなる
- `Unexpected token 'ℹ' ... is not valid JSON` の再発防止
