### PR TITLE
依存更新: react-i18next を v17 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "i18next": "^26.0.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-i18next": "^15.7.4",
+        "react-i18next": "^17.0.2",
         "typescript": "^5.9.3",
         "use-timer": "^2.0.1",
         "web-vitals": "^5.1.0"
@@ -4872,18 +4872,19 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
-      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.2.tgz",
+      "integrity": "sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "html-parse-stringify": "^3.0.1"
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 23.4.0",
+        "i18next": ">= 26.0.1",
         "react": ">= 16.8.0",
-        "typescript": "^5"
+        "typescript": "^5 || ^6"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -5716,6 +5717,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-timer": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "i18next": "^26.0.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-i18next": "^15.7.4",
+    "react-i18next": "^17.0.2",
     "typescript": "^5.9.3",
     "use-timer": "^2.0.1",
     "web-vitals": "^5.1.0"


### PR DESCRIPTION
## 概要
- `react-i18next` を `^15.7.4` から `^17.0.2` へメジャー更新しました（1依存1PR）。
- `package-lock.json` も更新しています。

## 変更ログ/Breaking Changes確認
- 参照: https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md
- `17.0.0` の Potentially breaking changes を確認。
  - `Trans` の自動生成キーにおけるHTMLタグ保持の挙動修正があり、
    auto-generated key に依存している場合は翻訳キー更新が必要になる可能性があります。
- 本リポジトリでは `npm test` と `npm run build` が通過し、既存コードへの即時の破壊的影響は確認されませんでした。

## 検証
- `npm test` ✅
- `npm run build` ✅
