### PR TITLE
chore: @types/node を v25 系へ更新

### DIFF
--- a/.pr-body-types-node-v25-rerun.md
+++ b/.pr-body-types-node-v25-rerun.md
@@ -1,0 +1,23 @@
+## 概要
+- `@types/node` を `^24.12.0` から `^25.6.0` へメジャー更新しました。
+- semver範囲外（major）更新のため、このPRでは **@types/node のみ** を更新しています。
+
+## 変更内容
+- `package.json` の `@types/node` を `^25.6.0` へ更新
+- `package-lock.json` を更新
+
+## 変更ログ / Breaking Changes の確認
+- Node.js v25.0.0 リリースノート: https://nodejs.org/en/blog/release/v25.0.0
+- 主な SemVer Major / 廃止整理
+  - `SlowBuffer` の EOL 化
+  - `fs.rmdir` の `recursive` オプション廃止整理
+  - 一部非推奨 API / アクセサの EOL 化
+- `@types/node` は Node.js API 型定義のメジャー追従です。今回のリポジトリではビルド補助用途が中心で、`npm test` / `npm run build` が通ることを確認しました。
+
+## 検証
+- `npm test` ✅
+- `npm run build` ✅
+
+## 補足
+- 以前の同系統PRはPR向けCIの既存不整合で見送りでしたが、その後CI周辺が更新されているため再実施しています。
+- CI（GitHub Actions `Deploy to Firebase Hosting on PR`）成功後にマージ予定です。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "colamone",
       "version": "1.0.0",
       "dependencies": {
-        "@types/node": "^24.12.0",
+        "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "i18next": "^26.0.3",
@@ -1524,12 +1524,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/react": {
@@ -5673,9 +5673,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "homepage": "./",
   "dependencies": {
-    "@types/node": "^24.12.0",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "i18next": "^26.0.3",


### PR DESCRIPTION
## 概要
- `@types/node` を `^24.12.0` から `^25.6.0` へメジャー更新しました。
- semver範囲外（major）更新のため、このPRでは **@types/node のみ** を更新しています。

## 変更内容
- `package.json` の `@types/node` を `^25.6.0` へ更新
- `package-lock.json` を更新

## 変更ログ / Breaking Changes の確認
- Node.js v25.0.0 リリースノート: https://nodejs.org/en/blog/release/v25.0.0
- 主な SemVer Major / 廃止整理
  - `SlowBuffer` の EOL 化
  - `fs.rmdir` の `recursive` オプション廃止整理
  - 一部非推奨 API / アクセサの EOL 化
- `@types/node` は Node.js API 型定義のメジャー追従です。今回のリポジトリではビルド補助用途が中心で、`npm test` / `npm run build` が通ることを確認しました。

## 検証
- `npm test` ✅
- `npm run build` ✅

## 補足
- 以前の同系統PRはPR向けCIの既存不整合で見送りでしたが、その後CI周辺が更新されているため再実施しています。
- CI（GitHub Actions `Deploy to Firebase Hosting on PR`）成功後にマージ予定です。
