### PR TITLE
chore: web-vitals を 5.2.0 へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react-i18next": "^17.0.2",
         "typescript": "^5.9.3",
         "use-timer": "^2.0.1",
-        "web-vitals": "^5.1.0"
+        "web-vitals": "^5.2.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.56.1",
@@ -5936,9 +5936,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
-      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
       "license": "Apache-2.0"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react-i18next": "^17.0.2",
     "typescript": "^5.9.3",
     "use-timer": "^2.0.1",
-    "web-vitals": "^5.1.0"
+    "web-vitals": "^5.2.0"
   },
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
## 概要
- `web-vitals` を `^5.1.0` から `^5.2.0` へ更新
- ローカルで `npm test` と `npm run build` を実行し、既存ビルドが維持されることを確認

## 確認
- `npm test`
- `npm run build`
