### PR TITLE
chore: Firebase action を Node 24 で実行する

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -9,6 +9,8 @@ name: Deploy to Firebase Hosting on merge
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -7,6 +7,8 @@ jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node


### PR DESCRIPTION
## 概要
- `FirebaseExtended/action-hosting-deploy@v0` に残っている Node 20 deprecation warning を抑えるため、workflow で `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` を設定
- 対象は Firebase Hosting の PR preview / merge deploy workflow

## 背景
action 自体の newer tag が見当たらず、直近では runner 側 opt-in で Node 24 動作を試すのが妥当と判断した。

## 確認
- PR preview workflow 成功確認予定
- merge 後 Hosting workflow 成功確認予定
