### PR TITLE
chore: Dependabot設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 2


### PR DESCRIPTION
## 概要
- npm 向けの Dependabot 設定を追加
- JavaScript 系依存関係の脆弱性更新が有効になるように設定
- `.npmrc` の `min-release-age=2880` に合わせて Dependabot 側にも `cooldown.default-days: 2` を追加

## 補足
- 監視対象ディレクトリはルート (`/`)
- 定期更新は weekly
