### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,29 @@
 version: 2
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    patterns:
+      - "*"
     cooldown:
       default-days: 2
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    multi-ecosystem-group: "dependency-updates"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    multi-ecosystem-group: "dependency-updates"


### PR DESCRIPTION
### Motivation
- Dependabot の PR を極力まとめてノイズを減らすため、npm と GitHub Actions の更新を可能な限り1つのグループに集約する設定にする。 
- セキュリティ更新は引き続き確実に追跡しつつ、個別 PR の増加を防ぐためワイルドカードでグルーピングする。 

### Description
- `.github/dependabot.yml` に `multi-ecosystem-groups` を追加し、`dependency-updates` グループを週次にスケジュールする設定を追加した。 
- `npm` と `github-actions` の `updates` エントリに `patterns: ["*"]` を追加し、両方を `multi-ecosystem-group: "dependency-updates"` に割り当てた。 
- `all-npm-security-updates` と `all-github-actions-security-updates` のグループを `applies-to: "security-updates"` で追加し、セキュリティ系の変更もワイルドカードでまとめるようにした。 
- 既存の `cooldown.default-days: 2` はそのまま維持している。 

### Testing
- YAML 構文チェックを Ruby で実行した: `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data["multi-ecosystem-groups"]; abort("bad updates") unless data["updates"].is_a?(Array) && data["updates"].size == 2; puts "dependabot.yml is valid YAML"'` — 成功。 
- `git diff --check` を実行して差分のホワイトスペース等の問題がないことを確認した — 成功。 
- 同等の YAML チェックを Python で実行しようとしたが、環境に `PyYAML` が無く失敗した: `python - <<'PY' ...` — 失敗（`PyYAML` 未インストール）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b5eb48bc83269c6c2b50e98dfc3d)