### PR TITLE
Upgrade TypeScript to 6.0.3 and switch tsconfig moduleResolution to bundler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.4",
         "react-i18next": "^17.0.6",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "use-timer": "^2.0.1",
         "web-vitals": "^5.2.0"
       },
@@ -5497,9 +5497,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.4",
     "react-i18next": "^17.0.6",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "use-timer": "^2.0.1",
     "web-vitals": "^5.2.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
### Motivation
- Upgrade the project to TypeScript `^6.0.3` and adjust the compiler configuration to use `moduleResolution: "bundler"` for compatibility with the newer TypeScript release.

### Description
- Updated `package.json` and `package-lock.json` to bump the `typescript` dependency to `^6.0.3` and refresh lockfile entries for TypeScript.
- Modified `tsconfig.json` to change `moduleResolution` from `node` to `bundler` to align with TypeScript 6 recommendations.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03cbbf3dfc8326b17523482b9faa52)