### PR TITLE
react と react-dom のバージョン不一致を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/react-dom": "^19.2.3",
         "i18next": "^26.0.3",
         "react": "^19.2.6",
-        "react-dom": "^19.2.4",
+        "react-dom": "^19.2.6",
         "react-i18next": "^17.0.6",
         "typescript": "^5.9.3",
         "use-timer": "^2.0.1",
@@ -4712,15 +4712,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-i18next": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@types/react-dom": "^19.2.3",
     "i18next": "^26.0.3",
     "react": "^19.2.6",
-    "react-dom": "^19.2.4",
+    "react-dom": "^19.2.6",
     "react-i18next": "^17.0.6",
     "typescript": "^5.9.3",
     "use-timer": "^2.0.1",


### PR DESCRIPTION
### Motivation
- `react` が `19.2.6` に上がった一方で `react-dom` が `19.2.4` のままだったため、ブラウザ実行時に Minified React error が発生して表示が壊れていました。 

### Description
- `package.json` の `react-dom` を `^19.2.6` に更新しました。 
- `npm install react-dom@19.2.6` を実行して `package-lock.json` の `node_modules/react-dom` 実体と peer dependency を `19.2.6` に揃えました。 
- 変更を `fix: align react-dom with react version` でコミットし、修正用のプルリクエストを作成しました。 

### Testing
- `npm test`（`vitest`）は全テストが通過しました。 
- `npm run build` が正常に完了しました。 
- `node -p "'react '+require('react/package.json').version+' / react-dom '+require('react-dom/package.json').version"` で `react 19.2.6 / react-dom 19.2.6` を確認しました。 
- `git diff --check` は問題ありませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03d58f8d208326984118e1b9bf37cc)