### PR TITLE
npm registryをflatt.techに設定

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=2880
+registry=https://npm.flatt.tech


### PR DESCRIPTION
### Motivation
- プロジェクトのnpmレジストリを内部ミラーの `https://npm.flatt.tech` に切り替するため。 

### Description
- `.npmrc` に `registry=https://npm.flatt.tech` を追記しました。 

### Testing
- `git diff --check` を実行して差分の問題がないことを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0442da88c88326b9eb26594cb16bfa)